### PR TITLE
Revert "Comment out x86 platform until the platform has been fixed."

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ from mender_test_containers.conftest import *
 
 TEST_CONTAINER_LIST = [
     MenderTestRaspbian,
-    #MenderTestQemux86_64,
+    MenderTestQemux86_64,
 ]
 
 @pytest.fixture(scope="session", params=TEST_CONTAINER_LIST)


### PR DESCRIPTION
This reverts commit 853fc0b404356b4f2bba3d47fc99a020d62cec54.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>