### PR TITLE
Make sure we get Docker IP address, by using inventory scripts.

### DIFF
--- a/onboarding-site/entrypoint.sh
+++ b/onboarding-site/entrypoint.sh
@@ -5,10 +5,11 @@ PROC=$(cat /proc/cpuinfo | grep "model name" | sed -n -e 's/^model name.*: //p' 
 DEVICE_TYPE=$(sed -e 's/^device_type=//' /var/lib/mender/device_type 2>/dev/null || uname -m)
 MENDER_VERSION=$(mender -version 2>/dev/null | head -n1)
 MENDER_VERSION=${MENDER_VERSION:-N/A}
+INVENTORY="$(for script in /usr/share/mender/inventory/mender-inventory-*; do $script; done)"
 cat >/var/www/localhost/htdocs/device-info.js <<EOF
   mender_server = {
     "Web server": "$(hostname)",
-    "Server address": "$(ip route get 1.2.3.4 | awk '{print $7}')"
+    "Server address(es)": "[ $(echo "$INVENTORY" | sed -ne '/^ipv4/{s/^[^=]*=//; s,/.*$,,; p}' | tr '\n' ' ')]"
   }
   mender_identity = {
     "Device ID": "",

--- a/onboarding-site/index.html
+++ b/onboarding-site/index.html
@@ -59,6 +59,9 @@
         justify-content: space-between;
         text-align: end;
       }
+      .attribute > div:first-of-type {
+        padding-right: 15px;
+      }
       #top-container {
         position: relative;
         display: flex;


### PR DESCRIPTION
This is important because on QEMU, we can only connect using the
Docker IP address, which is not on any interface.

This can generate multiple addresses, so take this into account when
rendering.

Changelog: Title

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>