### PR TITLE
Update download links for 2.1.0 and beyond.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,11 @@ env:
         # - AWS_S3_ACCESS_KEY_ID=''
         # - AWS_S3_SECRET_ACCESS_KEY=''
 
-        - MENDER_VERSION=2.0.0
-        - MENDER_ARTIFACT_VERSION=3.0.0
-        - INTEGRATION_VERSION=2.0.0
+        - MENDER_VERSION=2.1.0b1-build3
+        - MENDER_ARTIFACT_VERSION=3.1.0b1-build3
+        - INTEGRATION_VERSION=2.1.0b1-build3
         - ARTIFACT_NAME=mender-demo-artifact-$INTEGRATION_VERSION
+        - MENDER_DEB_VERSION=2.0.0
 
 before_install:
     - sudo apt update && sudo apt install -y python3-pip
@@ -55,7 +56,7 @@ jobs:
         - ( cd tests/mender_test_containers/docker/ && ./docker-build-raspbian )
 
         # Tests
-        - ( cd tests && python3 -m pytest -v --mender-version $MENDER_VERSION )
+        - ( cd tests && python3 -m pytest -v --mender-version $MENDER_VERSION --mender-deb-version $MENDER_DEB_VERSION )
 
         # Make a versioned copy too.
         - ( cd output

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN cp busybox /tmp/busybox_armhf
 
 ARG MENDER_ARTIFACT_VERSION=none
 RUN if [ "$MENDER_ARTIFACT_VERSION" = none ]; then echo "MENDER_ARTIFACT_VERSION must be set!" 1>&2; exit 1; fi
-RUN curl -f -o /usr/bin/mender-artifact https://d1b0l86ne08fsf.cloudfront.net/mender-artifact/$MENDER_ARTIFACT_VERSION/mender-artifact
+RUN curl -f -o /usr/bin/mender-artifact https://d1b0l86ne08fsf.cloudfront.net/mender-artifact/$MENDER_ARTIFACT_VERSION/linux/mender-artifact
 RUN chmod ugo+x /usr/bin/mender-artifact
 
 ARG MENDER_VERSION=none

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,12 @@ def setup_test_container_props(request):
 
 def pytest_addoption(parser):
     parser.addoption("--mender-version", required=True)
+    parser.addoption("--mender-deb-version", required=True)
 
 @pytest.fixture(scope="session")
 def mender_version(request):
     return request.config.getoption("--mender-version")
+
+@pytest.fixture(scope="session")
+def mender_deb_version(request):
+    return request.config.getoption("--mender-deb-version")


### PR DESCRIPTION
For this we need to also update to a temporary build tag, but we will
switch to the real one shortly.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>