### PR TITLE
Switch back to Mender 2.0.0, since 2.1 was postponed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ env:
         # - AWS_S3_ACCESS_KEY_ID=''
         # - AWS_S3_SECRET_ACCESS_KEY=''
 
-        - MENDER_VERSION=2.1.0b1-build3
-        - MENDER_ARTIFACT_VERSION=3.1.0b1-build3
-        - INTEGRATION_VERSION=2.1.0b1-build3
+        - MENDER_VERSION=2.0.0
+        - MENDER_ARTIFACT_VERSION=3.0.0
+        - INTEGRATION_VERSION=2.0.0
         - ARTIFACT_NAME=mender-demo-artifact-$INTEGRATION_VERSION
         - MENDER_DEB_VERSION=2.0.0
 


### PR DESCRIPTION
Changelog: none

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>