### PR TITLE
Update GitLab build versions to latest release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,11 +4,11 @@ variables:
   REPO_NAME: github.com/mendersoftware/mender-demo-artifact
   GITHUB_RELEASE_BINARY: mender-demo-artifact
   GITHUB_RELEASE_DEPLOY_REPO: mendersoftware/mender-demo-artifact
-  MENDER_VERSION: 'master'
-  MENDER_ARTIFACT_VERSION: '3.0.0'
-  INTEGRATION_VERSION: '2.0.0'
+  MENDER_VERSION: '2.1.1'
+  MENDER_ARTIFACT_VERSION: '3.2.0b1'
+  INTEGRATION_VERSION: '2.2.0b1'
   ARTIFACT_NAME: mender-demo-artifact-$INTEGRATION_VERSION
-  MENDER_DEB_VERSION: '2.0.0'
+  MENDER_DEB_VERSION: '2.1.1'
   RASPBIAN_VERSION: '2019-04-08'
 
 stages:


### PR DESCRIPTION
This was overlooked during the release which was still using Travis.