### PR TITLE
Make sure that errors are caught while starting the service.

### DIFF
--- a/onboarding-site/entrypoint.sh
+++ b/onboarding-site/entrypoint.sh
@@ -24,4 +24,11 @@ cat >/var/www/localhost/htdocs/device-info.js <<EOF
   }
 EOF
 cd /var/www/localhost/htdocs
-../busybox httpd -f -p 85
+../busybox httpd -f -p 85 &
+BUSYBOX_PID=$!
+# Trick to catch failures: Wait a few seconds for busybox to exit. If it does,
+# there's likely an error, and the kill will fail, which `set -e` will handle.
+sleep 3
+kill -0 $BUSYBOX_PID
+systemd-notify --ready || true
+wait $BUSYBOX_PID

--- a/state-scripts/ArtifactInstall_Leave_90_install_systemd_unit
+++ b/state-scripts/ArtifactInstall_Leave_90_install_systemd_unit
@@ -7,6 +7,7 @@ cat > /lib/systemd/system/mender-demo-artifact.service <<EOF
 WantedBy=multi-user.target
 
 [Service]
+Type=notify
 ExecStart=/var/www/localhost/entrypoint.sh
 EOF
 


### PR DESCRIPTION
Since we use a script, systemd considers the service successfully
launched as soon as this script runs. However, we want to delay
readiness until we know that the busybox server actually runs,
otherwise we get the error only later, when it is too late to act on
it.

Changelog: Title

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>