### PR TITLE
Fix pip dependencies

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ test:acceptance:
   script:
     - apk add python3 bash gcc openssh make openssl-dev libffi-dev libc-dev python3-dev
     - cd tests
-    - pip3 install --upgrade -r requirements.txt
+    - pip3 install -r requirements.txt
     - python3 -m pytest -v --mender-version $MENDER_VERSION --mender-deb-version $MENDER_DEB_VERSION
 
 publish:s3:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,18 +23,18 @@ include:
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-github-status-updates.yml'
 
-build:	
-  stage: build	
-  services:	
+build:
+  stage: build
+  services:
     - docker:19.03.5-dind
-  script:	
-    - docker build -t mender-demo-artifact --build-arg MENDER_ARTIFACT_VERSION=$MENDER_ARTIFACT_VERSION --build-arg MENDER_VERSION=$MENDER_VERSION --build-arg ARTIFACT_NAME=$ARTIFACT_NAME .	
-    # Extract artifact	
-    - mkdir output	
-    - docker run --rm -v $PWD/output:/output mender-demo-artifact	
-  artifacts:	
-    paths:	
-      - output/mender-demo-artifact.mender	
+  script:
+    - docker build -t mender-demo-artifact --build-arg MENDER_ARTIFACT_VERSION=$MENDER_ARTIFACT_VERSION --build-arg MENDER_VERSION=$MENDER_VERSION --build-arg ARTIFACT_NAME=$ARTIFACT_NAME .
+    # Extract artifact
+    - mkdir output
+    - docker run --rm -v $PWD/output:/output mender-demo-artifact
+  artifacts:
+    paths:
+      - output/mender-demo-artifact.mender
 
 test:acceptance:
   stage: test

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-pytest==5.2
+pytest==6.0.1
 fabric==2.5
 requests==2.22
 paramiko==2.6

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
 pytest==6.0.1
 fabric==2.5
-requests==2.22
+requests==2.24.0
 paramiko==2.7.2
 setuptools==50.0.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,4 +2,4 @@ pytest==6.0.1
 fabric==2.5
 requests==2.22
 paramiko==2.6
-setuptools==41.4
+setuptools==50.0.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
 pytest==6.0.1
 fabric==2.5
 requests==2.22
-paramiko==2.6
+paramiko==2.7.2
 setuptools==50.0.0


### PR DESCRIPTION
* [pipeline] Style: remove trailing spaces in build job

* [pipeline] Do not upgrade pip dependencies on run time
This defeats the purpose of locking the dependencies to known versions.
Use known versions here and let dependabot update the file instead.

And cherry-picks of #41, #42, #43 and #44.