### PR TITLE
fix: Bump to the Mender 3.3.0 release versions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,12 +2,12 @@ variables:
   REPO_NAME: github.com/mendersoftware/mender-demo-artifact
   GITHUB_RELEASE_BINARY: mender-demo-artifact
   GITHUB_RELEASE_DEPLOY_REPO: mendersoftware/mender-demo-artifact
-  MENDER_CLIENT_TAG_VERSION: '3.2.1'
-  MENDER_VERSION: 'mender-3.2.1'
-  MENDER_ARTIFACT_VERSION: '3.7.0'
-  INTEGRATION_VERSION: '3.2.1'
+  MENDER_CLIENT_TAG_VERSION: '3.3.0'
+  MENDER_VERSION: 'mender-3.3.0'
+  MENDER_ARTIFACT_VERSION: '3.8.0'
+  INTEGRATION_VERSION: '3.3.0'
   ARTIFACT_NAME: mender-demo-artifact-$INTEGRATION_VERSION
-  MENDER_DEB_VERSION: '3.2.1'
+  MENDER_DEB_VERSION: '3.3.0'
   S3_BUCKET_NAME: "mender-demo-artifacts"
 
 stages:


### PR DESCRIPTION
Changelog: Set the corresponding versions to align with the Mender 3.3.0 release
Ticket: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>