### PR TITLE
feat: set the correct software version for the Mender artifact

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,9 @@ RUN directory-artifact-gen \
     -o mender-demo-artifact.mender \
     /var/www/localhost \
     -- \
+    --software-filesystem rootfs \
+    --software-name mender-demo-artifact \
+    --software-version ${MENDER_VERSION} \
     -s state-scripts/ArtifactInstall_Leave_50_choose_busybox_arch \
     -s state-scripts/ArtifactInstall_Leave_90_install_systemd_unit \
     -s state-scripts/ArtifactRollback_Enter_00_remove_systemd_unit


### PR DESCRIPTION
Use the correct software versioning options; the resulting versioning provide will be: `rootfs-image.mender-demo-artifact.version: $VER`

Ticket: MEN-6026
Changelog: title

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>