### PR TITLE
feat: add `docker-client` to the list of supported device types

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -67,9 +67,9 @@ test:acceptance:
   script:
     - apk add --update python3 py3-pip bash gcc openssh-client make openssl-dev
       libffi-dev libc-dev python3-dev musl-dev rust cargo
-    - pip3 install --upgrade pip
+    - pip3 install --break-system-packages --upgrade pip
     - cd tests
-    - pip3 install -r requirements.txt
+    - pip3 install --break-system-packages -r requirements.txt
     - python3 -m pytest -v --mender-version $MENDER_VERSION --mender-deb-version $MENDER_DEB_VERSION
 
 publish:s3:

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN directory-artifact-gen \
     -t beaglebone \
     -t beaglebone-yocto \
     -t beaglebone-yocto-grub \
+    -t docker-client \
     -t generic-armv6 \
     -t generic-x86_64 \
     -t qemux86-64 \


### PR DESCRIPTION
Versions of `mendersoftware/mender-client-docker-addons` older than 3.7.x use `docker-client` as `device_type`. We add it to the demo artifact to make it back-compatible.

Changelog: Title
Ticket: None