### PR TITLE
feat(install): use systemV mechanism to install the demo as fallback.

### DIFF
--- a/onboarding-site/entrypoint.sh
+++ b/onboarding-site/entrypoint.sh
@@ -30,5 +30,8 @@ BUSYBOX_PID=$!
 # there's likely an error, and the kill will fail, which `set -e` will handle.
 sleep 3
 kill -0 $BUSYBOX_PID
-systemd-notify --ready || true
+if which systemd-notify 2>/dev/null; then
+ systemd-notify --ready || true
+fi
+echo "$BUSYBOX_PID" > /var/run/mender-demo-artifact
 wait $BUSYBOX_PID

--- a/state-scripts/ArtifactInstall_Leave_90_install_systemd_unit
+++ b/state-scripts/ArtifactInstall_Leave_90_install_systemd_unit
@@ -2,15 +2,66 @@
 
 set -e
 
-cat > /lib/systemd/system/mender-demo-artifact.service <<EOF
+if test -d /lib/systemd/system && \
+ which systemctl 2>/dev/null >&2 && \
+ pidof systemd; then
+ cat > /lib/systemd/system/mender-demo-artifact.service <<EOF
 [Install]
 WantedBy=multi-user.target
 
 [Service]
 Type=notify
 ExecStart=/data/www/localhost/entrypoint.sh
+
 EOF
 
-systemctl daemon-reload
-systemctl restart mender-demo-artifact
-systemctl enable mender-demo-artifact
+ systemctl daemon-reload
+ systemctl restart mender-demo-artifact
+ restart_rc=$?
+ systemctl enable mender-demo-artifact
+ if test "$restart_rc" = "0"; then
+  exit 0
+ fi
+fi
+
+if test ! -d /etc/init.d; then
+ mkdir -p /etc/init.d /etc/rc3.d
+fi
+
+cat > /etc/init.d/mender-demo-artifact <<"EOF"
+#!/bin/bash
+
+### BEGIN INIT INFO
+# Provides:		mender-demo-artifact
+# Default-Start:	2 3 4 5
+# Default-Stop:
+# Short-Description:	Mender Demo Artifact
+### END INIT INFO
+
+# /etc/init.d/mender-demo-artifact: start and stop the Mender Demo Artifact
+
+case "$1" in
+  start)
+    ( /data/www/localhost/entrypoint.sh < /dev/null >/dev/null 2>/dev/null 3>/dev/null & disown $!; ) &
+  ;;
+
+  stop)
+    kill -TERM `cat /var/run/mender-demo-artifact`
+    rm -f /var/run/mender-demo-artifact
+  ;;
+
+  *)
+    echo "Usage: /etc/init.d/mender-demo-artifact {start|stop}" || true
+    exit 1
+esac
+
+exit 0
+EOF
+
+chmod 755 /etc/init.d/mender-demo-artifact
+
+if test -d /etc/rc3.d; then
+ ln -s /etc/init.d/mender-demo-artifact /etc/rc3.d/S99mender-demo-artifact
+fi
+/etc/init.d/mender-demo-artifact start
+

--- a/state-scripts/ArtifactRollback_Enter_00_remove_systemd_unit
+++ b/state-scripts/ArtifactRollback_Enter_00_remove_systemd_unit
@@ -2,7 +2,17 @@
 
 # No 'set -e' here, proceed with everything.
 
-systemctl stop mender-demo-artifact
-systemctl disable mender-demo-artifact
-rm -f /lib/systemd/system/mender-demo-artifact.service
-systemctl daemon-reload
+if test -d /lib/systemd/system; then
+ if which systemctl 2>/dev/null >&2; then
+  if pidof systemd; then
+   systemctl stop mender-demo-artifact
+   systemctl disable mender-demo-artifact
+   rm -f /lib/systemd/system/mender-demo-artifact.service
+   systemctl daemon-reload
+   exit $?
+  fi
+ fi
+fi
+
+/etc/init.d/mender-demo-artifact stop
+rm -f /etc/init.d/mender-demo-artifact /etc/rc3.d/S99mender-demo-artifact

--- a/tests/test_demo_artifact.py
+++ b/tests/test_demo_artifact.py
@@ -59,7 +59,8 @@ class TestDemoArtifact():
                 key_filename=setup_test_container.key_filename)
             output = setup_tester_ssh_connection.sudo("mender-update install mender-demo-artifact.mender", warn=True)
             assert output.exited != 0
-            setup_tester_ssh_connection.run("! test -f /lib/systemd/system/mender-demo-artifact.service")
+            setup_tester_ssh_connection.run("! test -f /etc/init.d/mender-demo-artifact")
+            setup_tester_ssh_connection.run("! test -f /etc/rc3.d/S99mender-demo-artifact")
             output = setup_tester_ssh_connection.run("cat /data/www/localhost")
             assert output.stdout.strip() == "test_content"
 
@@ -88,5 +89,6 @@ class TestDemoArtifact():
 
     def test_rollback_demo_artifact(self, setup_test_container, setup_tester_ssh_connection):
         setup_tester_ssh_connection.sudo("mender-update rollback")
-        setup_tester_ssh_connection.run("! test -f /lib/systemd/system/mender-demo-artifact.service")
+        setup_tester_ssh_connection.run("! test -f /etc/init.d/mender-demo-artifact")
+        setup_tester_ssh_connection.run("! test -f /etc/rc3.d/S99mender-demo-artifact")
         self.check_valid_page(setup_test_container, setup_tester_ssh_connection, expect_fail=True)


### PR DESCRIPTION
feat(install): use systemV mechanism to install the demo as fallback.

If systemd is not present or not running we fall back to a /etc/init.d
mechanism.

Changelog: Make /etc/init.d a fallback for the systems where systemd is not present or not running
Ticket: MEN-7694
Signed-off-by: Peter Grzybowski <peter@northern.tech>