### PR TITLE
ci: Do not use Raspberry Pi container for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,6 @@ from mender_test_containers.container_props import *
 from mender_test_containers.conftest import *
 
 TEST_CONTAINER_LIST = [
-    MenderTestRaspbian,
     MenderTestQemux86_64,
 ]
 


### PR DESCRIPTION
It's slow and expensive, we can just use the x86_64 container, there should be no difference.

Ticket: QA-1086
Changelog: none