### PR TITLE
chore: Change to new commit linter

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,8 +29,7 @@ include:
     file:
       - qa-common/runner.yml
       - qa-common/retry.yml
-  - project: 'Northern.tech/Mender/mendertesting'
-    file: '.gitlab-ci-check-commits-signoffs.yml'
+  - component: gitlab.com/Northern.tech/Mender/mendertesting/commit-lint@master
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-github-status-updates.yml'
   - project: "Northern.tech/Mender/mendertesting"


### PR DESCRIPTION
Replace old commit linter with the new one in mendertesting/templates

Ticket: QA-1561