### PR TITLE
ci: only rebase renovate PRs on conflict and drop the schedule window

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,8 +5,7 @@
 
   "extends": [
     "config:recommended",
-    ":gitSignOff",
-    ":rebaseStalePrs"
+    ":gitSignOff"
   ],
 
   // CODEOWNERS drives reviewer assignment - keep its dependency file entries current.
@@ -17,8 +16,9 @@
   "semanticCommitType": "fix",
   "semanticCommitScope": "deps",
 
-  // Fallback window for weeks with no merges; the renovate CI job is the primary trigger.
-  "schedule": ["after 10pm on Monday", "before 6am on Tuesday"],
+  // Only rebase open PRs when they actually conflict. Rebasing every time the
+  // base branch moves restarts a pipeline for every open PR on each merge.
+  "rebaseWhen": "conflicted",
 
   // Was prHourlyLimit 0 (unlimited) while Dependabot still owned most ecosystems.
   "prHourlyLimit": 2,


### PR DESCRIPTION
Part of QA-1485

Two changes, both about how often renovate disturbs things

rebaseStalePrs rebased every open renovate PR whenever the base branch moved, so each merge to the default branch restarted a pipeline for every open renovate PR. Alf-Rune raised this as disruptive. rebaseWhen conflicted only rebases when the PR actually conflicts

The schedule window is removed so the GitLab pipeline schedule is the only thing deciding when renovate runs. Those two had drifted apart - the window was "after 10pm on Monday, before 6am on Tuesday" while several repos fire their schedule at 20:00-23:00 on Tuesday, which is outside it. Those runs did the full dependency lookup and then opened nothing, which is wasted GitHub API traffic and part of what we are seeing in QA-1726

After this the cron is the single source of truth, so spreading the schedules across the week actually works instead of silencing the repos we move

First run after this merges may open a batch of PRs if the repo has a backlog that the window was suppressing. prConcurrentLimit caps it
